### PR TITLE
Fix sorting of hidden and empty inlines

### DIFF
--- a/content_editor/static/content_editor/content_editor.js
+++ b/content_editor/static/content_editor/content_editor.js
@@ -315,6 +315,7 @@ django.jQuery(function($){
     orderMachine.sortable({
         handle: 'h3',
         placeholder: 'placeholder',
+        items: '.inline-related:not(.empty-form)',
         start: function(event, ui) {
             $(document).trigger('content-editor:deactivate', [ui.item]);
         },


### PR DESCRIPTION
Without this jQuery ui selector and when dealing with many inline types, i've experienced some problems with reordering inlines. This fixes the problem.