### PR TITLE
fixed issue with adding ckeditor and Django 2.0

### DIFF
--- a/content_editor/static/content_editor/content_editor.js
+++ b/content_editor/static/content_editor/content_editor.js
@@ -7,7 +7,7 @@ django.jQuery(function($){
 
     window.ContentEditor = {
         addContent: function addContent(plugin) {
-            $('#' + plugin + '_set-group .add-row a').click();
+            $('#' + plugin + '_set-group .add-row a')[0].click();
         },
         addPluginButton: function addPluginButton(plugin, html) {
             var doAdd = function(plugin, html, title) {


### PR DESCRIPTION
dajngo admin: Adding a new Richtext to a Page did not initialize CKEDITOR. Only after reloading the Admin Add Page.
Thats why I had to change the following line.
Can you imagine why? 
Why this error affect only me?
Im using newest django-ckeditor, django 2.0, chrome.

Thx 4 ur time 
Christof 
