### PR TITLE
adds simple check to distinguish dragging events

### DIFF
--- a/content_editor/static/content_editor/content_editor.js
+++ b/content_editor/static/content_editor/content_editor.js
@@ -109,15 +109,20 @@ django.jQuery(function ($) {
     inline.addEventListener(
       "dragover",
       function (e) {
-        e.preventDefault();
-        $(".fs-dragover").removeClass("fs-dragover");
-        e.target.closest(".inline-related").classList.add("fs-dragover");
+        if (window.__fs_dragging) {
+          e.preventDefault();
+          $(".fs-dragover").removeClass("fs-dragover");
+          e.target.closest(".inline-related").classList.add("fs-dragover");
+        }
       },
       true
     );
     inline.addEventListener("drop", function (e) {
-      e.preventDefault();
-      insertBefore(window.__fs_dragging, e.target.closest(".inline-related"));
+      if (window.__fs_dragging) {
+        e.preventDefault();
+        insertBefore(window.__fs_dragging, e.target.closest(".inline-related"));
+        window.__fs_dragging = null;
+      }
     });
 
     arg.find(">h3").attr("draggable", true);


### PR DESCRIPTION
Implementing plugins that have their own dragging
functionality in the admin is currently not possible
since the content-editor listeners catch all dragover
and drop events. This commit adds naive checks to these
listeners for the global object created when the
dragstart event occurs on inlines. This isolates
from dragstart events occuring outside the page thus
enabling dragging images into upload fields in plugins
like django-filer.
https://github.com/matthiask/django-content-editor/issues/16