### PR TITLE
Add draggable compatibility for Jazzmin

### DIFF
--- a/content_editor/static/content_editor/content_editor.css
+++ b/content_editor/static/content_editor/content_editor.css
@@ -400,18 +400,45 @@ h3[draggable] {
 
 /* JAZZMIN  start */
 
-#jazzy-navbar ~ .content-wrapper .card-header > .card-title[draggable]::before {
+#jazzy-navbar ~ .content-wrapper .order-machine {
+  padding-top: 12px;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable]::before {
   content: "drag_indicator";
   font-family: "Material Icons";
   font-size: 24px;
   position: relative;
-  top: 6px;
+  top: 7px;
   left: -2px;
 }
 
-#jazzy-navbar ~ .content-wrapper .card-body div[id*="cke_id_"]{
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable] {
+  margin-bottom: 9px;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable] + .card-tools.delete {
+  margin-top: 7px;
+  margin-right: 2px;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-body div[id*="cke_id_"]{
   margin-left: 0;
   width: 100% !important;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header {
+  padding: 0 1.25rem;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine .inline-related {
+  border: 0;
+  padding: 5px;
+  margin-top: 0;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-help {
+  margin-left: 25px;
 }
 
 /* JAZZMIN end */

--- a/content_editor/static/content_editor/content_editor.css
+++ b/content_editor/static/content_editor/content_editor.css
@@ -400,7 +400,7 @@ h3[draggable] {
 
 /* JAZZMIN  start */
 
-.order-machine .card-header > .card-title[draggable]::before {
+#jazzy-navbar ~ .content-wrapper .card-header > .card-title[draggable]::before {
   content: "drag_indicator";
   font-family: "Material Icons";
   font-size: 24px;
@@ -409,7 +409,7 @@ h3[draggable] {
   left: -2px;
 }
 
-.card-body div[id*="cke_id_"]{
+#jazzy-navbar ~ .content-wrapper .card-body div[id*="cke_id_"]{
   margin-left: 0;
   width: 100% !important;
 }

--- a/content_editor/static/content_editor/content_editor.css
+++ b/content_editor/static/content_editor/content_editor.css
@@ -107,6 +107,16 @@ h3[draggable] {
   left: -2px;
 }
 
+/* JAZZMIN DRAGGABLE */
+.order-machine .card-header > .card-title[draggable]::before {
+  content: "drag_indicator";
+  font-family: "Material Icons";
+  font-size: 24px;
+  position: relative;
+  top: 6px;
+  left: -2px;
+}
+
 .order-machine .inline-related > h3 > b,
 .order-machine h3 .inline_label {
   overflow: hidden;

--- a/content_editor/static/content_editor/content_editor.css
+++ b/content_editor/static/content_editor/content_editor.css
@@ -107,16 +107,6 @@ h3[draggable] {
   left: -2px;
 }
 
-/* JAZZMIN DRAGGABLE */
-.order-machine .card-header > .card-title[draggable]::before {
-  content: "drag_indicator";
-  font-family: "Material Icons";
-  font-size: 24px;
-  position: relative;
-  top: 6px;
-  left: -2px;
-}
-
 .order-machine .inline-related > h3 > b,
 .order-machine h3 .inline_label {
   overflow: hidden;
@@ -404,3 +394,24 @@ h3[draggable] {
     bottom: -20px;
   }
 }
+
+/* =====| OVERRIDES |===== */
+
+
+/* JAZZMIN  start */
+
+.order-machine .card-header > .card-title[draggable]::before {
+  content: "drag_indicator";
+  font-family: "Material Icons";
+  font-size: 24px;
+  position: relative;
+  top: 6px;
+  left: -2px;
+}
+
+.card-body div[id*="cke_id_"]{
+  margin-left: 0;
+  width: 100% !important;
+}
+
+/* JAZZMIN end */

--- a/content_editor/static/content_editor/content_editor.js
+++ b/content_editor/static/content_editor/content_editor.js
@@ -162,63 +162,63 @@ django.jQuery(function ($) {
   })()
 
   function ensureDraggable(arg) {
-    if (arg.hasClass("empty-form") || arg.hasClass("fs-draggable")) return
+    if (arg.hasClass("empty-form") || arg.hasClass("fs-draggable")) return;
 
-    const inline = arg[0]
+    const inline = arg[0];
 
     inline.addEventListener("dragstart", function (e) {
       // Only handle events from [draggable] elements
-      if (!e.target.closest("h3[draggable]")) return
+      if (!e.target.closest("h3[draggable]")) return;
 
       // window.__fs_dragging = inline;
-      window.__fs_dragging = e.target.closest(".inline-related")
-      window.__fs_dragging.classList.add("fs-dragging")
-      window.__fs_dragging.classList.add("selected")
+      window.__fs_dragging = e.target.closest(".inline-related");
+      window.__fs_dragging.classList.add("fs-dragging");
+      window.__fs_dragging.classList.add("selected");
 
-      e.dataTransfer.dropEffect = "move"
-      e.dataTransfer.effectAllowed = "move"
+      e.dataTransfer.dropEffect = "move";
+      e.dataTransfer.effectAllowed = "move";
       try {
-        e.dataTransfer.setData("text/plain", "")
+        e.dataTransfer.setData("text/plain", "");
       } catch (e) {
         // IE11 needs this.
       }
-    })
+    });
     inline.addEventListener("dragend", function () {
-      $(".fs-dragging").removeClass("fs-dragging")
-      $(".fs-dragover").removeClass("fs-dragover")
+      $(".fs-dragging").removeClass("fs-dragging");
+      $(".fs-dragover").removeClass("fs-dragover");
       qsa(".order-machine .inline-related.selected").forEach((el) =>
         el.classList.remove("selected")
-      )
-    })
+      );
+    });
     inline.addEventListener(
       "dragover",
       function (e) {
         if (window.__fs_dragging) {
-          e.preventDefault()
-          $(".fs-dragover").removeClass("fs-dragover")
-          e.target.closest(".inline-related").classList.add("fs-dragover")
+          e.preventDefault();
+          $(".fs-dragover").removeClass("fs-dragover");
+          e.target.closest(".inline-related").classList.add("fs-dragover");
         }
       },
       true
-    )
+    );
     inline.addEventListener("drop", function (e) {
       if (window.__fs_dragging) {
-        e.preventDefault()
-        const before = e.target.closest(".inline-related")
+        e.preventDefault();
+        const before = e.target.closest(".inline-related");
         const toMove = qsa(".order-machine .inline-related.selected").map(
           (inline) => [inline, +inline.style.order]
-        )
-        toMove.sort((a, b) => a[1] - b[1])
+        );
+        toMove.sort((a, b) => a[1] - b[1]);
         toMove.forEach((row) => {
-          insertBefore(row[0], before)
-          row[0].classList.remove("selected")
-        })
-        window.__fs_dragging = null
+          insertBefore(row[0], before);
+          row[0].classList.remove("selected");
+        });
+        window.__fs_dragging = null;
       }
-    })
+    });
 
-    arg.find("h3").attr("draggable", true)
-    arg.addClass("fs-draggable")
+    arg.find(">h3, .card-title").attr("draggable", true); // Default admin, Jazzmin
+    arg.addClass("fs-draggable");
   }
 
   function reorderInlines(context) {

--- a/content_editor/static/content_editor/content_editor.js
+++ b/content_editor/static/content_editor/content_editor.js
@@ -217,7 +217,7 @@ django.jQuery(function ($) {
       }
     })
 
-    arg.find(">h3").attr("draggable", true)
+    arg.find("h3").attr("draggable", true)
     arg.addClass("fs-draggable")
   }
 


### PR DESCRIPTION
Added minimal compatibility for Jazzmin theme. This restores the draggable icon to the stacked inline header. There's still no support for collapsing inlines. I might return to this sometime down the road.