### PR TITLE
Jazzmin - Additional CSS improvements

### DIFF
--- a/content_editor/static/content_editor/content_editor.css
+++ b/content_editor/static/content_editor/content_editor.css
@@ -403,11 +403,7 @@ h3[draggable] {
   padding-top: 12px;
 }
 
-#jazzy-navbar
-  ~ .content-wrapper
-  .order-machine-wrapper
-  .card-header
-  > .card-title[draggable]::before {
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable]::before {
   content: "drag_indicator";
   font-family: "Material Icons";
   font-size: 24px;
@@ -416,29 +412,34 @@ h3[draggable] {
   left: -2px;
 }
 
-#jazzy-navbar
-  ~ .content-wrapper
-  .order-machine-wrapper
-  .card-header
-  > .card-title[draggable] {
+#jazzy-navbar ~ .content-wrapper .card .card-body > h6 {
+  display: none
+}
+
+#jazzy-navbar ~ .content-wrapper .card .card-body .tabs > .tab {
+  border-radius: 4px 4px 0 0;
+  background: inherit;
+  color: inherit;
+}
+
+#jazzy-navbar ~ .content-wrapper .card .card-body .tabs > .active {
+  background: rgba(200,200,200, 0.2);
+}
+
+#jazzy-navbar ~ .content-wrapper .card .card-body .tabs > .active:hover {
+  background: rgba(200,200,200, 0.5)
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable] {
   margin-bottom: 9px;
 }
 
-#jazzy-navbar
-  ~ .content-wrapper
-  .order-machine-wrapper
-  .card-header
-  > .card-title[draggable]
-  + .card-tools.delete {
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-header > .card-title[draggable] + .card-tools.delete {
   margin-top: 7px;
   margin-right: 2px;
 }
 
-#jazzy-navbar
-  ~ .content-wrapper
-  .order-machine-wrapper
-  .card-body
-  div[id*="cke_id_"] {
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper .card-body div[id*="cke_id_"]{
   margin-left: 0;
   width: 100% !important;
 }
@@ -455,6 +456,40 @@ h3[draggable] {
 
 #jazzy-navbar ~ .content-wrapper .order-machine-help {
   margin-left: 25px;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control {
+  width: 35px;
+  overflow: hidden;
+  display: grid;
+}
+
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed {
+  margin-right: 34px;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control > *,
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control > * > * {
+  padding: 0;
+  border: 0;
+  max-width: 42px;
+  line-break: none;
+  white-space: nowrap;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control span.plugin-button-title {
+  display: none;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control .plugin-button {
+  margin-left: 6px;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control .plugin-button-icon {
+  margin-left: 10px;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control .plugin-button-icon .material-icons {
+  margin-left: -3px;
+}
+#jazzy-navbar ~ .content-wrapper .order-machine-wrapper.collapsed .machine-control .plugin-button-icon {
+  margin-right: 100%;
+  margin-left: 0;
 }
 
 /* JAZZMIN end */


### PR DESCRIPTION
Improved the region tab to look more in line with Jazzmin while being semi-theme neutral. Used some hackish CSS to shrink the sidebar when collapsed. Fixed order machine right margin. 

Regarding fieldset titles, I didn't look into the code enough to understand how content-editor is inserting the order-machine into the page, but for some reason, Jazzmin creates a fieldset for every single content type. For now, all H6's are hidden. I think this can be removed if content-editor is improved in the future to support fieldsets assignments. 

While fieldsets aren't supported, it's required that any models with content-editor have `changeform_format_overrides` for the parent model set to `'single'`, i.e.

```py
JAZZMIN_SETTINGS = {
    ...
    "changeform_format_overrides": {
        "myapp.page": "single"
    },
    ....
}
```

This is because tabbed pages are the default, and order-machine will appear under the first content type fieldset tab.