### PR TITLE
Export Type in __all__

### DIFF
--- a/content_editor/models.py
+++ b/content_editor/models.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 
 
-__all__ = ("Region", "Template", "create_plugin_base")
+__all__ = ("Type", "Region", "Template", "create_plugin_base")
 
 
 class Type(dict):


### PR DESCRIPTION
Type is imported in https://github.com/matthiask/feincms3/blob/main/feincms3/applications.py#L10 so it should be in __all__