### PR TITLE
Expand description in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,13 @@
 django-content-editor -- Editing structured content
 ===================================================
 
+Django’s builtin admin application provides a really good and usable
+administration interface for creating and updating content.
+``django-content-editor`` extends Django’s inlines mechanism with an interface
+and tools for managing and rendering heterogenous collections of content as are
+often necessary for content management systems. For example, articles may be
+composed of text blocks with images and videos interspersed throughout.
+
 `Documentation on Read the Docs <http://django-content-editor.readthedocs.org/en/latest/>`_
 
 .. image:: https://github.com/matthiask/django-content-editor/actions/workflows/tests.yml/badge.svg


### PR DESCRIPTION
The PyPI page has *no descripton* — just the link to the docs. 

Added the first paragraph from the docs to the README to give as least *some* context when landing there.